### PR TITLE
fix: cobi host name resolution

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -158,6 +158,8 @@ services:
       - orderbook
       - redis
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 networks:
   default:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Configured Docker to recognize `host.docker.internal` for seamless network connectivity between the container and the host system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->