### PR TITLE
fix: min required confirmations for solana

### DIFF
--- a/resources/config/quote/config.json
+++ b/resources/config/quote/config.json
@@ -140,7 +140,7 @@
       "min_amount": "1000",
       "max_amount": "10000000000",
       "min_source_timelock": 20,
-      "min_source_confirmations": 3,
+      "min_source_confirmations": 2,
       "min_price": 1.0001,
       "fee": 1
     },
@@ -188,7 +188,7 @@
       "min_amount": "1000",
       "max_amount": "10000000000",
       "min_source_timelock": 20,
-      "min_source_confirmations": 3,
+      "min_source_confirmations": 2,
       "min_price": 1.0001,
       "fee": 1
     },
@@ -260,7 +260,7 @@
       "min_amount": "1000",
       "max_amount": "10000000000",
       "min_source_timelock": 20,
-      "min_source_confirmations": 3,
+      "min_source_confirmations": 2,
       "min_price": 1.0001,
       "fee": 1
     },


### PR DESCRIPTION
Fixed the min required confirmations for Solana.
As the transaction is considered finalised when there are 2 confirmations after the latest Solana watcher changes.