### PR TITLE
fix : change starknet-devnet block generation trigger to transaction

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -293,7 +293,7 @@ services:
   starknet-devnet:
     image: shardlabs/starknet-devnet-rs:latest
     container_name: starknet-devnet
-    command: ["--seed", "1", "--dump-on", "exit", "--dump-path", "/data/dump.json", "--block-generation-on", "10"]
+    command: ["--seed", "1", "--dump-on", "exit", "--dump-path", "/data/dump.json", "--block-generation-on", "transaction"]
     ports:
       - "8547:5050"
     volumes:


### PR DESCRIPTION
Switch from 10-second interval to immediate block generation on transaction to prevent invalid nonce errors 