### PR TITLE
Feat/update nginx

### DIFF
--- a/resources/config/nginx/nginx.conf
+++ b/resources/config/nginx/nginx.conf
@@ -215,3 +215,105 @@ server {
         add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
     }
 }
+
+
+server {
+    listen 80;
+    server_name api.localhost;
+
+    location /orders {
+        return 301 /orders/;
+    }
+
+    location /orders/ {
+        resolver 127.0.0.11 valid=10s;
+        resolver_timeout 5s;
+        rewrite ^/orders/(.*)$ /$1 break;
+        proxy_pass http://orderbookV2:4455;
+        proxy_set_header Host orderbookV2;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_name orderbookV2;
+    }
+
+    location /auth {
+        return 301 /auth/;
+    }
+
+    location /auth/ {
+        resolver 127.0.0.11 valid=10s;
+        resolver_timeout 5s;
+        rewrite ^/auth/(.*)$ /$1 break;
+        proxy_pass http://authenticator:4427;
+        proxy_set_header Host authenticator;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_name authenticator;
+    }
+
+    location /info {
+        return 301 /info/;
+    }
+
+    location /info/ {
+        resolver 127.0.0.11 valid=10s;
+        resolver_timeout 5s;
+        rewrite ^/info/(.*)$ /$1 break;
+        proxy_pass http://info:4232;
+        proxy_set_header Host info;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_name info;
+    }
+
+    location /relayer {
+        return 301 /relayer/;
+    }
+
+    location /relayer/ {
+        resolver 127.0.0.11 valid=10s;
+        resolver_timeout 5s;
+        rewrite ^/relayer/(.*)$ /$1 break;
+        proxy_pass http://relayer:4426;
+        proxy_set_header Host relayer;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_name relayer;
+    }
+
+    location /quote {
+        return 301 /quote/;
+    }
+
+    location /quote/ {
+        resolver 127.0.0.11 valid=10s;
+        resolver_timeout 5s;
+        rewrite ^/quote/(.*)$ /$1 break;
+        proxy_pass http://quote:6969;
+        proxy_set_header Host quote;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_name quote;
+    }
+
+}

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       - chopsticks
       - garden-db
     volumes:
-      - "./config/garden-evm-watcher/config.json:/app/docker_config.json"
+      - "./config/garden-evm-watcher/config.json:/app/config.json"
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
This pull request introduces a new `server` block in the Nginx configuration to set up reverse proxy rules for multiple services and updates a volume mapping in the Docker Compose configuration. These changes aim to enhance routing and service configuration.

### Nginx Configuration Enhancements:
* Added a new `server` block in `resources/config/nginx/nginx.conf` to define reverse proxy rules for the following services:
  - `/orders/` routed to `orderbookV2` on port 4455.
  - `/auth/` routed to `authenticator` on port 4427.
  - `/info/` routed to `info` on port 4232.
  - `/relayer/` routed to `relayer` on port 4426.
  - `/quote/` routed to `quote` on port 6969.
  Each route includes headers for forwarding host, protocol, and client IP, along with SSL-related settings.

### Docker Compose Configuration Update:
* Updated the volume mapping for the `garden-evm-watcher` service in `resources/docker-compose.yml` to use `/app/config.json` instead of `/app/docker_config.json`.