### PR TITLE
support for the Ripple (XRP) ledger

### DIFF
--- a/go.go
+++ b/go.go
@@ -20,7 +20,7 @@ func (m *Merry) Start() error {
 	}
 	composePath := filepath.Join(home, ".merry", "docker-compose.yml")
 
-	bashCmd := runDockerCompose(composePath, "up", "-d", "esplora", "ethereum-explorer", "arbitrum-explorer", "nginx", "garden-evm-watcher", "garden-db", "quote", "bit-ponder", "cobiv2", "relayer", "bit-indexer", "authenticator", "orderbookV2","info")
+	bashCmd := runDockerCompose(composePath, "up", "-d", "esplora", "ethereum-explorer", "arbitrum-explorer", "nginx", "garden-evm-watcher", "garden-db", "quote", "bit-ponder", "cobiv2", "relayer", "bit-indexer", "authenticator", "orderbookV2", "info", "rippled")
 	if m.IsHeadless && m.IsBare {
 		bashCmd = runDockerCompose(composePath, "up", "-d", "chopsticks", "ethereum", "arbitrum", "cosigner")
 	} else if m.IsHeadless {

--- a/resources/config/nginx/nginx.conf
+++ b/resources/config/nginx/nginx.conf
@@ -298,5 +298,46 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+        location /rippled/rpc {
+        return 301 /rippled_rpc/;
+    }
+
+    location /rippled/rpc/ {
+        set $backend "rippled:5005";
+        rewrite ^/auth/(.*)$ /$1 break;
+        proxy_pass http://$backend;
+        proxy_set_header Host authenticator;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /rippled/ws {
+        return 301 /rippled/ws/;
+    }
+
+    location /rippled/ws/ {
+        # Strip prefix
+        rewrite ^/rippled/ws/(.*)$ /$1 break;
+
+        # Proxy to Docker container named "rippled"
+        proxy_pass http://rippled:6006;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Force the Host header to what rippled expects
+        proxy_set_header Host localhost;
+
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+
 }
 

--- a/resources/config/rippled/rippled.cfg
+++ b/resources/config/rippled/rippled.cfg
@@ -1,0 +1,38 @@
+[server]
+port_rpc_admin_local
+port_peer
+port_ws_admin_local
+
+[port_rpc_admin_local]
+port = 5005
+ip = 0.0.0.0
+protocol = http
+admin = 0.0.0.0/0
+
+[port_ws_admin_local]
+port = 6006
+ip = 0.0.0.0
+protocol = ws
+admin = 0.0.0.0/0
+
+[port_peer]
+port = 51235
+ip = 0.0.0.0
+protocol = peer
+
+[node_db]
+type=NuDB
+path=/var/lib/rippled/db/nudb
+open_files=2000
+file_size_mb=64
+file_divisions=32
+
+[database_path]
+/var/lib/rippled/db
+
+[ledger_history]
+256
+
+[validation_quorum]
+3
+

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -249,6 +249,22 @@ services:
     ports:
       - "11818:11818"
     restart: unless-stopped
+
+  rippled:
+    image: xrpllabsofficial/xrpld:latest
+    container_name: rippled
+    platform: linux/amd64   
+    ports:
+      - "6006:6006"         
+      - "51235:51235"       
+      - "5005:5005"         
+    volumes:
+      - "./config/rippled/rippled.cfg:/config/rippled.cfg"
+      - "./volumes/rippled-data:/var/lib/rippled"  
+    environment:
+      ENV_ARGS: "--start"     
+    restart: unless-stopped   
+
   nginx:
     image: "nginx:latest"
     container_name: nginx

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -289,6 +289,7 @@ services:
       - relayer
       - authenticator
       - quote
+      - rippled
 networks:
   default:
     name: merry


### PR DESCRIPTION
This pull request introduces support for the Ripple (XRP) ledger by integrating the `rippled` service into the application. Key changes include updates to the Docker Compose configuration, Nginx routing, and the addition of a dedicated configuration file for `rippled`.

### Ripple Integration:

* **Docker Compose Updates**: Added a new `rippled` service to `resources/docker-compose.yml`, specifying its image, ports, volumes, and environment variables. Also included `rippled` in the list of services to be started. [[1]](diffhunk://#diff-692949d3905b0cc83c1971bf723baaac51c51c3c914aa7f3590abcb1f4e70c32R252-R267) [[2]](diffhunk://#diff-692949d3905b0cc83c1971bf723baaac51c51c3c914aa7f3590abcb1f4e70c32R292)
* **Rippled Configuration**: Created a new configuration file `resources/config/rippled/rippled.cfg` to define server ports, database settings, and ledger history for `rippled`.

### Nginx Routing for Rippled:

* **Routing Rules**: Updated `resources/config/nginx/nginx.conf` to add routing for `rippled` RPC and WebSocket endpoints, including proxy settings and rewrite rules for `/rippled/rpc` and `/rippled/ws`.

### Minor Update:

* **Service Start Command**: Modified the `Start()` method in `go.go` to include `rippled` in the list of services started by Docker Compose.