### PR TITLE
add environment variables for cosigner

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -249,6 +249,13 @@ services:
     ports:
       - "11818:11818"
     restart: unless-stopped
+    environment:
+      ELECTRS_URL: "http://electrs:30000"
+      RPC_URL: "http://bitcoin:18443"
+      RPC_USERNAME: "admin"
+      RPC_PASSWORD: "123"
+      BITCOIN_NETWORK: "regtest"
+      COSIGNER_WIF: "cRRnaQ4Yjrp4gP1M29LaryN8SaYvDGrnPozmjk2qPPfp5z2Mch3J"
 
   rippled:
     image: xrpllabsofficial/xrpld:latest


### PR DESCRIPTION
This pull request introduces environment variables to the `services` section of the `resources/docker-compose.yml` file, configuring the Bitcoin and Electrum RPC services for a regtest environment.

Configuration changes:

* Added environment variables `ELECTRS_URL`, `RPC_URL`, `RPC_USERNAME`, `RPC_PASSWORD`, `BITCOIN_NETWORK`, and `COSIGNER_WIF` to the `services` section to enable integration with Electrum and Bitcoin RPC services in a regtest setup.