### PR TITLE
add Starknet proxy configuration to nginx

### DIFF
--- a/resources/config/nginx/nginx.conf
+++ b/resources/config/nginx/nginx.conf
@@ -347,7 +347,20 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /starknet {
+        return 301 /starknet/;
+    }
 
+    location /starknet/ {
+        set $backend "starknet-relayer:4436";
+        rewrite ^/starknet/(.*)$ /$1 break;
+        proxy_pass http://$backend;
+        proxy_set_header Host starknet;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
 }
 


### PR DESCRIPTION
This pull request adds new routing rules to the Nginx configuration to handle requests for the `/starknet` path. The changes include setting up a redirect and proxying requests to a backend service.

### Nginx Configuration Updates:
* Added a new location block to redirect `/starknet` requests to `/starknet/`.
* Configured a location block for `/starknet/` to proxy requests to the `starknet-relayer` service on port 4436, including setting appropriate headers for forwarding and real IP information.